### PR TITLE
fix(ci): allow deployment workflow to run via manual dispatch

### DIFF
--- a/.github/workflows/deploy-wildcat-docker.yml
+++ b/.github/workflows/deploy-wildcat-docker.yml
@@ -26,7 +26,6 @@ jobs:
       contents: read
       deployments: write
 
-    # define environments
     strategy:
       matrix:
         include:
@@ -42,11 +41,6 @@ jobs:
             vite_keycloak_url: ${{ vars.VITE_KEYCLOAK_URL_DOCKER }}
             vite_keycloak_realm: 'dev'
             vite_keycloak_client_id: 'bff-dashboard'
-    
-    # only run job for the selected environment on manual dispatch or on push to a tag
-    if: |
-      github.event_name == 'push' || 
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == matrix.environment)
 
     steps:
       - name: Checkout repository
@@ -55,7 +49,6 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      # only allow tags on manual dispatch
       - name: Validate Tag on Manual Dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -94,10 +87,9 @@ jobs:
     
       - name: Deploy ${{ matrix.environment }} to Cloudflare Pages (PRODUCTION)
         id: deploy_production
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == matrix.environment
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Target the production branch ('main' or 'master') for manual deployments
           command: pages deploy dist --project-name=${{ matrix.project_name }} --branch=master


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
• Fixed CI workflow deployment logic for manual dispatch
• Removed conditional job execution that prevented manual deployments
• Updated production deployment condition to check environment input


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-wildcat-docker.yml</strong><dd><code>Fix workflow manual dispatch execution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-wildcat-docker.yml

• Removed job-level conditional that blocked manual dispatch execution<br> <br>• Updated production deployment condition to validate environment <br>input<br> • Cleaned up comments and formatting


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/wildcat-dashboard-ui/pull/62/files#diff-cceccac821c71baf344b506e31de04bda721412d3394103a2297218a9187a8ce">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>