### PR TITLE
#215 % #213 probably fix

### DIFF
--- a/src/pages/quotes/StatusQuotePage.tsx
+++ b/src/pages/quotes/StatusQuotePage.tsx
@@ -23,6 +23,9 @@ import { useIntl } from "react-intl"
 type QuoteStatus = "Accepted" | "Denied" | "OfferExpired" | "Offered" | "Pending" | "Rejected" | "Canceled" | "Minting"
 type SortBy = "status-asc" | "status-desc" | "sum-asc" | "sum-desc" | "maturity-asc" | "maturity-desc"
 
+const RETRY_COUNT = 2
+const retryDelay = (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000)
+
 function getStatusVariant(status: string): "default" | "secondary" | "destructive" | "success" | "outline" {
   switch (status) {
     case "Offered":
@@ -60,7 +63,7 @@ function Loader() {
   )
 }
 
-function QuoteItemCard({ quote, isLoading, searchQuery }: { quote: LightInfo; isLoading: boolean; searchQuery: string }) {
+function QuoteItemCard({ quote, searchQuery }: { quote: LightInfo; searchQuery: string }) {
   const intl = useIntl()
   const navigate = useNavigate()
 
@@ -68,8 +71,8 @@ function QuoteItemCard({ quote, isLoading, searchQuery }: { quote: LightInfo; is
     ...getQuoteOptions({
       path: { qid: quote.id }
     }),
-    retry: 2,
-    retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000),
+    retry: RETRY_COUNT,
+    retryDelay,
     enabled: !!quote.id,
   })
 
@@ -111,7 +114,7 @@ function QuoteItemCard({ quote, isLoading, searchQuery }: { quote: LightInfo; is
                 <HighlightText text={quote.id} highlight={searchQuery} />
               </Link>
             </span>
-            <span>{isLoading && <LoaderIcon className="stroke-1 animate-spin" />}</span>
+            <span></span>
           </div>
         </CardTitle>
         <div className="flex gap-2">
@@ -131,7 +134,7 @@ function QuoteItemCard({ quote, isLoading, searchQuery }: { quote: LightInfo; is
       </div>
       <div className="flex justify-between items-center gap-4 px-4 py-2">
         <div>
-          <Button size="sm" className="max-w-sm px-12" disabled={isLoading} onClick={handleQuoteClick}>
+          <Button size="sm" className="max-w-sm px-12" onClick={handleQuoteClick}>
             {intl.formatMessage({
               id: "quotes.card.view",
               defaultMessage: "View"
@@ -183,8 +186,8 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
 
   const { data, isFetching, error, isLoading } = useQuery({
     ...listQuotesOptions(),
-    retry: 2,
-    retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000),
+    retry: RETRY_COUNT,
+    retryDelay,
   })
 
   /* TODO: optimize this with pagination or batch fetching if API supports it */
@@ -193,8 +196,8 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
       ...getQuoteOptions({
         path: { qid: quote.id }
       }),
-      retry: 2,
-      retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000),
+      retry: RETRY_COUNT,
+      retryDelay,
       enabled: !!quote.id,
     }))
   })
@@ -367,7 +370,7 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
           }
           return (
             <div key={quote.id || `quote-fallback-${index}`}>
-              <QuoteItemCard quote={quote} isLoading={isLoading} searchQuery={searchQuery} />
+              <QuoteItemCard quote={quote} searchQuery={searchQuery} />
             </div>
           )
         })}

--- a/src/pages/quotes/StatusQuotePage.tsx
+++ b/src/pages/quotes/StatusQuotePage.tsx
@@ -68,7 +68,8 @@ function QuoteItemCard({ quote, isLoading, searchQuery }: { quote: LightInfo; is
     ...getQuoteOptions({
       path: { qid: quote.id }
     }),
-    retry: 1,
+    retry: 2,
+    retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000),
     enabled: !!quote.id,
   })
 
@@ -182,7 +183,8 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
 
   const { data, isFetching, error, isLoading } = useQuery({
     ...listQuotesOptions(),
-    retry: 1,
+    retry: 2,
+    retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000),
   })
 
   /* TODO: optimize this with pagination or batch fetching if API supports it */
@@ -191,7 +193,8 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
       ...getQuoteOptions({
         path: { qid: quote.id }
       }),
-      retry: 1,
+      retry: 2,
+      retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 10_000),
       enabled: !!quote.id,
     }))
   })
@@ -339,11 +342,11 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
         />
       </div>
 
-      <div className="flex items-center gap-1">
+      <div className="flex items-center justify-center">
         <LoaderIcon
           className={cn("stroke-1", {
-            "animate-spin": isFetching,
-            invisible: !isFetching,
+            "animate-spin": isFetching && !isLoading,
+            invisible: !isFetching || isLoading,
           })}
         />
       </div>
@@ -364,7 +367,7 @@ function QuoteList({ status }: { status?: QuoteStatus }) {
           }
           return (
             <div key={quote.id || `quote-fallback-${index}`}>
-              <QuoteItemCard quote={quote} isLoading={isFetching} searchQuery={searchQuery} />
+              <QuoteItemCard quote={quote} isLoading={isLoading} searchQuery={searchQuery} />
             </div>
           )
         })}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Increase retry attempts from 1 to 2 for quote queries

- Add exponential backoff retry delay strategy (1s to 10s max)

- Fix loading state display logic in quote list

- Pass correct loading state to QuoteItemCard component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query Configuration"] -->|"Increase retry count"| B["retry: 2"]
  A -->|"Add exponential backoff"| C["retryDelay function"]
  D["Loading State Logic"] -->|"Fix visibility condition"| E["Show spinner only when fetching and not loading"]
  F["QuoteItemCard Props"] -->|"Pass correct state"| G["isLoading instead of isFetching"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatusQuotePage.tsx</strong><dd><code>Enhance retry logic and fix loading state display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/quotes/StatusQuotePage.tsx

<ul><li>Increased retry count from 1 to 2 for three separate query <br>configurations (QuoteItemCard, QuoteList main query, and <br>quoteDetailsQueries)<br> <li> Added exponential backoff retry delay function with 1s base and 10s <br>maximum across all queries<br> <li> Fixed loading spinner visibility logic to show only when actively <br>fetching and not in initial loading state<br> <li> Changed QuoteItemCard isLoading prop from isFetching to isLoading for <br>accurate loading state representation<br> <li> Adjusted spinner container styling from gap-1 to justify-center for <br>better alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/wildcat-dashboard-ui/pull/218/files#diff-e24ef792a64b6d63f8bfcd2f17c26ad4448bd5d8006c0a79563edfaf5a879ca7">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

