### PR TITLE
Use default-days for the github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,7 @@ updates:
       - "dependencies"
       - "github-actions"
     cooldown:
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 3
     assignees:
       - "JulianVIE"
 


### PR DESCRIPTION
Dependabot rejects `semver-major-days`, `semver-minor-days` and `semver-patch-days` for the `github-actions` ecosystem, and it rejects the **whole file** when any property is invalid — so no updates have been running in this repository since that cooldown landed.

My mistake: I copied the shape from the package blocks without checking that ecosystem accepts it.

`default-days` is the key it takes. Three days on every update, the value the patch cooldown already used. Verified against Dependabot's own validator on `helm-charts` before opening this.