### PR TITLE
ci: build the image once, call it from nightly and release

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,54 @@
+name: build and push image
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: "docker/metadata-action tag directives"
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: "bcr-wdc-dashboard-ui"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - id: meta
+        name: Metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: ${{ inputs.tags }}
+
+      - id: push
+        name: Build & push ${{ env.IMAGE_NAME }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ github.repository }}/${{ env.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ github.repository }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,9 @@
 name: build and push nightly image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:
@@ -9,48 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  IMAGE_NAME: "bcr-wdc-dashboard-ui"
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Login to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - id: meta
-        name: Metadata
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=nightly
-
-      - id: push
-        name: Build & push ${{ env.IMAGE_NAME }}
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ github.repository }}/${{ env.IMAGE_NAME }}
-          cache-to: type=gha,mode=max,scope=${{ github.repository }}/${{ env.IMAGE_NAME }}
+  nightly:
+    uses: ./.github/workflows/build-image.yml
+    with:
+      tags: type=raw,value=nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: release tagged image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     tags:
@@ -14,49 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  IMAGE_NAME: "bcr-wdc-dashboard-ui"
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Login to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - id: meta
-        name: Metadata
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
-
-      - id: push
-        name: Build & push ${{ env.IMAGE_NAME }}
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ github.repository }}/${{ env.IMAGE_NAME }}
-          cache-to: type=gha,mode=max,scope=${{ github.repository }}/${{ env.IMAGE_NAME }}
+  release:
+    uses: ./.github/workflows/build-image.yml
+    with:
+      tags: |
+        type=semver,pattern={{version}}
+        type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## What

The image build recipe now exists once. `build-image.yml` is a `workflow_call` workflow taking a single input; `nightly.yml` and `release.yml` become thin callers.

118 lines become 104 — the line count is not the point. The point is that **the build steps existed twice and now exist once**.

## Why

`nightly.yml` (56 lines) and `release.yml` (62 lines) were the same workflow twice over. Measured, they differed in **exactly three places**:

| | `nightly.yml` | `release.yml` |
|---|---|---|
| `name:` | build and push nightly image | release tagged image |
| trigger | `push: branches: [dev]` | `push: tags: ["v*.*.*"]` + `workflow_dispatch` with a `tag` input |
| metadata `tags:` | `type=raw,value=nightly` | `type=semver,pattern={{version}}` + the dispatch override |

Checkout, GHCR login, buildx setup, the metadata `images:` list, and build-push with its `gha` cache scopes were **byte-identical**. So the only genuine parameter is the tag strategy, and that is the single input.

This is the first of the three duplicated build/nightly pairs this repository set carries; the other two are excluded for stated reasons below.

## Why this pair first

It is the safest of the three: **one registry (`ghcr.io` only), no attestation steps, and no secret beyond the automatic `GITHUB_TOKEN`.** The digest divergence that broke `Wildcat`'s nightly for six days — where a single `steps.push.outputs.digest` cannot describe a push to two registries — cannot arise here.

## Local reusable workflows are already the house pattern

`Wildcat-deployment` defines `deploy-gcp.yml` and `deploy-wildcat.yml` as `workflow_call` and calls them from **21 sites**. This propagates an established pattern rather than introducing one.

## Two things that changed beyond pure extraction, both deliberate

- **`permissions` is now declared at workflow level in each caller.** It has to be: a called workflow's `GITHUB_TOKEN` can only be *equal to or more restrictive than* the caller's, so a caller with no `permissions` block cannot delegate `packages: write` and the push to GHCR would fail. The scopes are unchanged — `contents: read, packages: write`, exactly what the `build` job already declared — and each caller has a single job, so nothing is widened.
- **`env: IMAGE_NAME` moved into the reusable workflow**, since that is where it is consumed.

**Check names change**, as they must for any reusable workflow: `build` becomes `nightly / build` and `release / build`. That is more informative than two checks both called `build`, and the two never appeared on the same commit anyway (one fires on `dev`, the other on tags).

## Based on `dev`, deliberately

`dev` is where this repository is developed — **52 of the last 60 merged pull requests targeted `dev`, only 8 targeted `master`** — it is where `nightly.yml` actually fires, and it carries the newer action pins. Basing a structural change on `master` while the team works on `dev` would guarantee a conflict with Dependabot's pin bumps in exactly these files. The action SHAs here are `dev`'s current ones, untouched.

## Verification

Equivalence was proved rather than asserted, by parsing:

- The reusable workflow's `build` job is **byte-identical** to `nightly.yml`'s, with only the two-line `tags: |` block replaced by `tags: ${{ inputs.tags }}`.
- The two originals' job blocks are **identical to each other** once the tag directives are removed — which is what makes one reusable workflow correct rather than convenient.
- `name`, `on` and `concurrency` compare **equal** between each original and its caller, as parsed values.
- Each caller passes exactly the directives its original hardcoded: `nightly` -> `type=raw,value=nightly`; `release` -> `type=semver,pattern={{version}}` plus the `workflow_dispatch` override.
- The reusable job's `permissions` equal the original job's, and `IMAGE_NAME` is preserved.

The checker was negative-tested first: given a copy with one trigger widened and `packages: write` downgraded to `read`, it failed on both and named them.

**The proof that matters cannot be had before merge.** The next push to `dev` must publish `ghcr.io/bitcreditprotocol/bcr-wdc-dashboard-ui:nightly` and move its digest. A diff proves nothing about a registry. Rollback is one revert — `build-image.yml` is additive and inert until a caller references it.
