### PR TITLE
ci: give each job a timeout derived from its own history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   validate:
     name: Validate (style, lint, test, build)
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 25


### PR DESCRIPTION
## What

One `timeout-minutes` line per job, placed immediately before `runs-on`. Nothing
else changes.

| workflow | job | samples | trimmed p95 | worst seen | timeout |
|---|---|---|---|---|---|
| `ci.yml` | `validate` | 15 | 1.2 min | 1.2 min | **15 min** |

## Why

A job with no `timeout-minutes` runs to GitHub's default of **six hours** before
anything stops it. Every value above comes from this repository's own completed
runs in the last 90 days.

The rule is the **trimmed p95, doubled, floor 15 minutes**: drop the largest
sample when there are fewer than ten, take the p95 of what remains, double it,
round up to 5.

The trimming is the point. A raw p95 sets the limit from the very hang it is
meant to catch when samples are few — elsewhere in this organisation that would
have produced a **220-minute** timeout for a job whose median is 42 seconds,
fixed by the single 110-minute hang the timeout exists to catch. Doubling means no
healthy run can trip it, which matters more than a tight bound: **a timeout that
fires on a good build is worse than no timeout at all.**

## How it was verified

Both versions of each file parsed and compared: same job keys, same `needs`
graph, same triggers, `permissions`, `concurrency`, `env`, and the same steps.
The only difference is the added line per job.

The differ was shown to catch five distinct tampers before being trusted — a
wrong value, a dropped step, a missing timeout, widened permissions and a changed
trigger. The trigger case is why it is worth saying: YAML parses a top-level
`on:` as the boolean `true`, so the first version compared `nil` with `nil` and
passed a narrowed trigger. Only the negative test found that.

Durations come from each job's `completed_at − started_at` in `runs/{id}/jobs`,
never from a run's `updated_at` — that field moves when artifacts expire and has
produced a 403-day "duration" in this organisation before.

Every value is asserted programmatically to be **at least twice** its job's
trimmed p95, and every file was read back from the branch and `cmp`-compared.

Remaining check, and it cannot come from a diff: the next ordinary run of each
workflow should complete well inside its limit.